### PR TITLE
Disable shallow clone of fgpu2 lib to enable checkout of specific commit by hash

### DIFF
--- a/cmake/flamegpu2.cmake
+++ b/cmake/flamegpu2.cmake
@@ -17,7 +17,7 @@ FetchContent_Declare(
     flamegpu2
     GIT_REPOSITORY ${FLAMEGPU_REPOSITORY}
     GIT_TAG        ${FLAMEGPU_VERSION}
-    GIT_SHALLOW    1
+    GIT_SHALLOW    0
     GIT_PROGRESS   ON
     # UPDATE_DISCONNECTED   ON
 )


### PR DESCRIPTION
Temporarily disable shallow cloning of flamegpu2 so that the benchmark builds using the given instructions. Issue #14 relates to fixing this properly.